### PR TITLE
Use vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .DS_Store
 .env*
 !.env.tmp
+.vercel

--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
 # otp-admin-ui
 
-Front end application to manage OpenTripPlanner and [otp-middleware](https://github.com/ibi-group/otp-middleware).
+Front end application to manage OpenTripPlanner (OTP) and
+[otp-middleware](https://github.com/ibi-group/otp-middleware). This application
+acts as a dashboard for managing OTP user accounts, third party
+applications that have access to the OTP API, and other components involved.
 
-## Getting started
+## Requirements
 
-```
+This application depends on having both OTP and otp-middleware running. API
+access for third party applications is heavily dependent on AWS services like
+AWS API Gateway.
+
+## Development
+
+To get started with development:
+1. Download the repo.
+2. Update the local config and install dependencies.
+3. Kick off the dev instance.
+
+```bash
 git clone https://github.com/ibi-group/otp-admin-ui.git
 cd otp-admin-ui
 cp .env.tmp .env.build
@@ -15,4 +29,14 @@ yarn
 yarn dev
 # Note: ensure otp-middleware is running
 # (assumed to be at http://localhost:4567)
+```
+
+## Deployment
+
+To deploy this site, first make sure `vercel` is installed globally. Then, run
+`yarn deploy`.
+
+```bash
+yarn global add vercel
+yarn deploy
 ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "next build",
     "dev": "next",
-    "deploy": "now",
+    "deploy": "vercel",
     "lint": "mastarm lint components pages --quiet"
   },
   "dependencies": {


### PR DESCRIPTION
In April, Now/Zeit changed to Vercel: https://vercel.com/blog/zeit-is-now-vercel

This PR swaps out the `now` CLI tool for `vercel`.