### PR TITLE
Fix scope syntax.

### DIFF
--- a/util/constants.js
+++ b/util/constants.js
@@ -1,4 +1,5 @@
 // Auth0 scopes must now be separated by spaces (not commas).
+// (See https://auth0.com/docs/flows/call-your-api-using-the-authorization-code-flow#parameters.)
 export const AUTH0_SCOPE = 'admin-user api-user'
 
 export const ADMIN_USER_URL = `${process.env.API_BASE_URL}/api/admin/user`

--- a/util/constants.js
+++ b/util/constants.js
@@ -1,4 +1,5 @@
-export const AUTH0_SCOPE = 'admin-user,api-user'
+// Auth0 scopes must now be separated by spaces (not commas).
+export const AUTH0_SCOPE = 'admin-user api-user'
 
 export const ADMIN_USER_URL = `${process.env.API_BASE_URL}/api/admin/user`
 export const API_USER_URL = `${process.env.API_BASE_URL}/api/secure/application`


### PR DESCRIPTION
There was a change in the Auth0 scope syntax that is preventing granting of rights to admin users in the OTP Admin Dashboard. EDIT: Basically, scopes must be separated with spaces ([see Auth0 docs](https://auth0.com/docs/flows/call-your-api-using-the-authorization-code-flow#parameters)). This PR addresses that (in addition to proper permissions settings in the auth0 tenants).