### PR TITLE
Handle Bugsnag events that don't have exceptions

### DIFF
--- a/components/ErrorEventsDashboard.js
+++ b/components/ErrorEventsDashboard.js
@@ -62,8 +62,11 @@ function ErrorEventsDashboard () {
                       <tr key={eventIndex}>
                         <td className='component'>{event.projectName}</td>
                         <td className='details'>
-                          {event.exceptions.map((e, i) =>
-                            <span key={i}><strong>{e.errorClass}</strong>: {e.message}</span>)
+                          {event.exceptions
+                            ? event.exceptions.map((e, i) => (
+                              <span key={i}><strong>{e.errorClass}</strong>: {e.message}</span>
+                            ))
+                            : <>No exception information.</>
                           }
                         </td>
                         <td className='date'>{moment(event.received).format('D MMM h:mm a')}</td>


### PR DESCRIPTION
This PR prevents a UI crash if a Bugsnag event is created that does not include exception information, e.g. when passing invalid data during a test to https://github.com/ibi-group/otp-middleware/blob/dev/src/main/java/org/opentripplanner/middleware/bugsnag/BugsnagWebhook.java#L23.