### PR TITLE
Show api key name

### DIFF
--- a/components/ApiKeyRow.js
+++ b/components/ApiKeyRow.js
@@ -26,7 +26,7 @@ export default class ApiKeyRow extends Component {
     return (
       <ListGroup.Item as='li'>
         <Key size={20} style={{marginRight: 10}} />
-        {apiKey.keyId}{' '}
+        {apiKey.name} ({apiKey.keyId}){' '}
         {isAdmin &&
           <Button
             className='float-right'

--- a/components/ApiKeyUsageChart.js
+++ b/components/ApiKeyUsageChart.js
@@ -31,7 +31,7 @@ class ApiKeyUsageChart extends Component {
     this.setState({value: null})
   }
 
-  _getChartTitle = () => {
+  _renderChartTitle = () => {
     const { aggregatedView, isAdmin } = this.props
     // Do not show chart title for non-admin users.
     if (!isAdmin) return null
@@ -97,14 +97,15 @@ class ApiKeyUsageChart extends Component {
     return requestData
   }
 
-  _getKeyInfo = () => {
+  _renderKeyInfo = () => {
     const {id} = this.props
     if (!id) return null
     const apiUser = this._getApiUser()
     const keyName = apiUser?.apiKeys?.find(key => key.keyId === id)?.name
     return (
       <p>
-        <span><Key size={20} style={{marginRight: 10}} />
+        <span>
+          <Key size={20} style={{marginRight: 10}} />
           {keyName ? `${keyName} (${id})` : id}
         </span>
         {apiUser &&
@@ -164,8 +165,8 @@ class ApiKeyUsageChart extends Component {
     const maxY = rangeMax === 0 ? 10 : Math.ceil(rangeMax / 10) * 10
     return (
       <div className='usage-list' style={{display: 'inline-block'}}>
-        {this._getChartTitle()}
-        {this._getKeyInfo()}
+        {this._renderChartTitle()}
+        {this._renderKeyInfo()}
         <XYPlot
           xDomain={[timestamp - 2 * ONE_DAY_MILLIS, timestamp + 30 * ONE_DAY_MILLIS]}
           // Round up max y value to the nearest 10

--- a/components/ApiKeyUsageChart.js
+++ b/components/ApiKeyUsageChart.js
@@ -101,7 +101,7 @@ class ApiKeyUsageChart extends Component {
     const {id} = this.props
     if (!id) return null
     const apiUser = this._getApiUser()
-    const keyName = apiUser?.apiKeys?.find(key => key.id === id)?.name
+    const keyName = apiUser?.apiKeys?.find(key => key.keyId === id)?.name
     return (
       <p>
         <span><Key size={20} style={{marginRight: 10}} />

--- a/components/ApiKeyUsageChart.js
+++ b/components/ApiKeyUsageChart.js
@@ -99,11 +99,14 @@ class ApiKeyUsageChart extends Component {
 
   _getKeyInfo = () => {
     const {id} = this.props
+    if (!id) return null
     const apiUser = this._getApiUser()
-    const keyLabel = apiUser ? `${apiUser.name} (${id})` : id
+    const keyName = apiUser?.apiKeys?.find(key => key.id === id) || id
     return (
       <p>
-        <span><Key size={20} style={{marginRight: 10}} />{keyLabel}</span>
+        <span><Key size={20} style={{marginRight: 10}} />
+          {keyName ? `${keyName} (${id})` : id}
+        </span>
         {apiUser &&
           <small>
             <Button

--- a/components/ApiKeyUsageChart.js
+++ b/components/ApiKeyUsageChart.js
@@ -101,7 +101,7 @@ class ApiKeyUsageChart extends Component {
     const {id} = this.props
     if (!id) return null
     const apiUser = this._getApiUser()
-    const keyName = apiUser?.apiKeys?.find(key => key.id === id) || id
+    const keyName = apiUser?.apiKeys?.find(key => key.id === id)?.name
     return (
       <p>
         <span><Key size={20} style={{marginRight: 10}} />

--- a/components/ApiKeyUsageChart.js
+++ b/components/ApiKeyUsageChart.js
@@ -97,6 +97,28 @@ class ApiKeyUsageChart extends Component {
     return requestData
   }
 
+  _getKeyInfo = () => {
+    const {id} = this.props
+    const apiUser = this._getApiUser()
+    const keyLabel = apiUser ? `${apiUser.name} (${id})` : id
+    return (
+      <p>
+        <span><Key size={20} style={{marginRight: 10}} />{keyLabel}</span>
+        {apiUser &&
+          <small>
+            <Button
+              onClick={this._viewApiKey}
+              size='sm'
+              variant='link'
+            >
+              click to view key
+            </Button>
+          </small>
+        }
+      </p>
+    )
+  }
+
   _getApiUser = () => this.props.aggregatedView
     ? null
     : this.props.plan.apiUsers[this.props.id]
@@ -121,7 +143,6 @@ class ApiKeyUsageChart extends Component {
       console.warn('Cannot show non-aggregated view if id prop is undefined.')
       return null
     }
-    const apiUser = this._getApiUser()
     // Render the # of requests per API key on each day beginning
     // with the start date.
     const requestData = this._getRequestData()
@@ -141,20 +162,7 @@ class ApiKeyUsageChart extends Component {
     return (
       <div className='usage-list' style={{display: 'inline-block'}}>
         {this._getChartTitle()}
-        <p>
-          {id && <span><Key size={20} style={{marginRight: 10}} />{id}</span>}
-          {apiUser &&
-            <small>
-              <Button
-                onClick={this._viewApiKey}
-                size='sm'
-                variant='link'
-              >
-                click to view key
-              </Button>
-            </small>
-          }
-        </p>
+        {this._getKeyInfo()}
         <XYPlot
           xDomain={[timestamp - 2 * ONE_DAY_MILLIS, timestamp + 30 * ONE_DAY_MILLIS]}
           // Round up max y value to the nearest 10


### PR DESCRIPTION
This PR updates the API Key List to show the API key name. This is helpful for when/if we want to update the API Key name to be a bit more descriptive (e.g., when showing the different usage for the RMCE web app vs. the kiosk vs. other apps).
![image](https://user-images.githubusercontent.com/2370911/132581506-fd736a36-dca2-4fa2-be76-200ea609460b.png)
