### PR TITLE
Correctly specify node 18 version

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 17.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v1
         with:
-          node-version: 17.x
+          node-version: 18.x
       - name: Install npm packages using cache
         uses: bahmutov/npm-install@v1
         with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      - name: Use Node.js 18.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 18.x
       - name: Install npm packages using cache
         uses: bahmutov/npm-install@v1
         with:

--- a/__tests__/e2e/e2e.ts
+++ b/__tests__/e2e/e2e.ts
@@ -32,13 +32,13 @@ describe('end-to-end tests', () => {
           password: process.env.E2E_PASSWORD,
           username: process.env.E2E_USERNAME_API
         })
+        await page.keyboard.press('Enter')
       } catch (error) {
         console.warn(error)
         console.warn(
           'You may have forgotten to set E2E_PASSWORD or E2E_USERNAME_API environment variables'
         )
       }
-      await page.click('button[type="submit"]')
 
       await page.waitForNavigation({ waitUntil: 'networkidle2' })
 
@@ -84,13 +84,13 @@ describe('end-to-end tests', () => {
           password: process.env.E2E_PASSWORD,
           username: E2E_USERNAME
         })
+        await page.keyboard.press('Enter')
       } catch (error) {
         console.warn(error)
         console.warn(
           'You may have forgotten to set E2E_PASSWORD or E2E_USERNAME environment variables'
         )
       }
-      await page.click('button[type="submit"]')
 
       await page.waitForNavigation({ waitUntil: 'networkidle2' })
 
@@ -170,13 +170,13 @@ describe('end-to-end tests', () => {
           password: process.env.E2E_PASSWORD,
           username: NEW_CDP_USERNAME
         })
+        await page.keyboard.press('Enter')
       } catch (error) {
         console.warn(error)
         console.warn(
           'You may have forgotten to set E2E_PASSWORD or E2E_NEW_USERNAME_1 environment variables'
         )
       }
-      await page.click('button[type="submit"]')
 
       await page.waitForNavigation({ waitUntil: 'networkidle2' })
 

--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "otp-admin-ui",
   "version": "1.0.0",
   "main": "index.js",
-  "engines": {
-    "node": ">=14.x"
-  },
+  "engines": { "node": "18.x" },
   "license": "MIT",
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
Zeit requires node 18 (the version of node this project uses) to be specified in a specific way. This PR does this.
