### PR TITLE
Daily Stats

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,9 +26,15 @@ jobs:
 
       - name: Download middleware
         run: "git clone https://github.com/ibi-group/otp-middleware.git"
+      - name: Change directory
+        # TODO: remove before merging!!
+        run: "cd otp-middleware"
       - name: Checkout daily stats branch
         # TODO: remove before merging!!
-        run: "git checkout origin/daily-stats"
+        run: "git checkout daily-stats"
+      - name: Revert directory
+        # TODO: remove before merging!!
+        run: "cd .."
       - name: Load e2e middleware config
         run: echo $E2E_OTP_MIDDLEWARE_DOCKER_CONFIG_BASE64 | base64 -d > otp-middleware/configurations/default/env.docker.yml
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,9 +26,6 @@ jobs:
 
       - name: Download middleware
         run: "git clone https://github.com/ibi-group/otp-middleware.git"
-      - name: Checkout daily stats branch
-        # TODO: remove before merging!!
-        run: "cd otp-middleware && git checkout origin/daily-stats && cd .."
       - name: Load e2e middleware config
         run: echo $E2E_OTP_MIDDLEWARE_DOCKER_CONFIG_BASE64 | base64 -d > otp-middleware/configurations/default/env.docker.yml
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
         run: "git clone https://github.com/ibi-group/otp-middleware.git"
       - name: Checkout daily stats branch
         # TODO: remove before merging!!
-        run: "git checkout daily-stats"
+        run: "git checkout origin/daily-stats"
       - name: Load e2e middleware config
         run: echo $E2E_OTP_MIDDLEWARE_DOCKER_CONFIG_BASE64 | base64 -d > otp-middleware/configurations/default/env.docker.yml
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,6 +26,9 @@ jobs:
 
       - name: Download middleware
         run: "git clone https://github.com/ibi-group/otp-middleware.git"
+      - name: Checkout daily stats branch
+        # TODO: remove before merging!!
+        run: "git checkout daily-stats"
       - name: Load e2e middleware config
         run: echo $E2E_OTP_MIDDLEWARE_DOCKER_CONFIG_BASE64 | base64 -d > otp-middleware/configurations/default/env.docker.yml
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,15 +26,9 @@ jobs:
 
       - name: Download middleware
         run: "git clone https://github.com/ibi-group/otp-middleware.git"
-      - name: Change directory
-        # TODO: remove before merging!!
-        run: "cd otp-middleware"
       - name: Checkout daily stats branch
         # TODO: remove before merging!!
-        run: "git checkout daily-stats"
-      - name: Revert directory
-        # TODO: remove before merging!!
-        run: "cd .."
+        run: "cd otp-middleware && git checkout origin/daily-stats && cd .."
       - name: Load e2e middleware config
         run: echo $E2E_OTP_MIDDLEWARE_DOCKER_CONFIG_BASE64 | base64 -d > otp-middleware/configurations/default/env.docker.yml
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v1
         with:
-          node-version: 18.x
+          node-version: 22.x
       - name: Install npm packages using cache
         uses: bahmutov/npm-install@v1
         with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 18.x
+      - name: Use Node.js 22.x
         uses: actions/setup-node@v1
         with:
-          node-version: 18.x
+          node-version: 22.x
       - name: Install npm packages using cache
         uses: bahmutov/npm-install@v1
         with:

--- a/__tests__/e2e/e2e.ts
+++ b/__tests__/e2e/e2e.ts
@@ -1,4 +1,5 @@
 import 'expect-puppeteer'
+import fs from 'fs'
 
 import { server } from '../../jest-puppeteer.config'
 import { waitForDownload } from '../util/waitForDownload'
@@ -199,6 +200,9 @@ describe('end-to-end tests', () => {
         downloadPath: '/tmp'
       })
 
+      const downloadingFiles = fs.readdirSync('/tmp')
+      console.log('Downloaded files before click:', downloadingFiles.toString())
+      
       await expect(page).toClick('div', { text: uploadString })
 
       await waitForDownload('anon-trip-data')

--- a/__tests__/e2e/e2e.ts
+++ b/__tests__/e2e/e2e.ts
@@ -206,7 +206,8 @@ describe('end-to-end tests', () => {
       await expect(page).toClick('div', { text: uploadString })
 
       const link = await page.waitForSelector('a.fake-download-link')
-      console.log('Link href', link?.getProperty('href'))
+      const href = await link?.getProperty('href')
+      console.log('Link href', href)
 
       await waitForDownload('anon-trip-data')
       await expect(page).toMatch('You last downloaded', { timeout: 6000 })

--- a/__tests__/e2e/e2e.ts
+++ b/__tests__/e2e/e2e.ts
@@ -205,6 +205,9 @@ describe('end-to-end tests', () => {
       
       await expect(page).toClick('div', { text: uploadString })
 
+      const link = await page.waitForSelector('a.fake-download-link')
+      console.log('Link href', link?.getProperty('href'))
+
       await waitForDownload('anon-trip-data')
       await expect(page).toMatch('You last downloaded', { timeout: 6000 })
     })

--- a/__tests__/e2e/e2e.ts
+++ b/__tests__/e2e/e2e.ts
@@ -1,5 +1,4 @@
 import 'expect-puppeteer'
-import fs from 'fs'
 
 import { server } from '../../jest-puppeteer.config'
 import { waitForDownload } from '../util/waitForDownload'
@@ -200,14 +199,7 @@ describe('end-to-end tests', () => {
         downloadPath: '/tmp'
       })
 
-      const downloadingFiles = fs.readdirSync('/tmp')
-      console.log('Downloaded files before click:', downloadingFiles.toString())
-      
       await expect(page).toClick('button', { text: uploadString })
-
-      const link = await page.waitForSelector('a.fake-download-link')
-      const href = await link?.getProperty('href')
-      console.log('Link href', href)
 
       await waitForDownload('anon-trip-data')
       await expect(page).toMatch('You last downloaded', { timeout: 6000 })

--- a/__tests__/e2e/e2e.ts
+++ b/__tests__/e2e/e2e.ts
@@ -203,7 +203,7 @@ describe('end-to-end tests', () => {
       const downloadingFiles = fs.readdirSync('/tmp')
       console.log('Downloaded files before click:', downloadingFiles.toString())
       
-      await expect(page).toClick('div', { text: uploadString })
+      await expect(page).toClick('button', { text: uploadString })
 
       const link = await page.waitForSelector('a.fake-download-link')
       const href = await link?.getProperty('href')

--- a/__tests__/util/waitForDownload.ts
+++ b/__tests__/util/waitForDownload.ts
@@ -25,7 +25,6 @@ export function waitForDownload(downloadedFileName: string): Promise<void> {
       }
 
       if (waitAttempts++ > WAIT_ATTEMPTS) {
-        console.log('Downloaded files:', downloadingFiles.toString())
         clearInterval(check)
         reject(new Error('failed to find crdownload file!'))
       }

--- a/__tests__/util/waitForDownload.ts
+++ b/__tests__/util/waitForDownload.ts
@@ -11,6 +11,7 @@ export function waitForDownload(downloadedFileName: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const check = setInterval(() => {
       const downloadingFiles = fs.readdirSync('/tmp')
+      console.log('Downloaded files:', downloadingFiles.toString())
       const downloadedFileFound = !!downloadingFiles.find((file) => {
         // In some cases the file downloads before this is fired.
         // In this case, check for the completed download

--- a/__tests__/util/waitForDownload.ts
+++ b/__tests__/util/waitForDownload.ts
@@ -11,7 +11,6 @@ export function waitForDownload(downloadedFileName: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const check = setInterval(() => {
       const downloadingFiles = fs.readdirSync('/tmp')
-      console.log('Downloaded files:', downloadingFiles.toString())
       const downloadedFileFound = !!downloadingFiles.find((file) => {
         // In some cases the file downloads before this is fired.
         // In this case, check for the completed download
@@ -26,6 +25,7 @@ export function waitForDownload(downloadedFileName: string): Promise<void> {
       }
 
       if (waitAttempts++ > WAIT_ATTEMPTS) {
+        console.log('Downloaded files:', downloadingFiles.toString())
         clearInterval(check)
         reject(new Error('failed to find crdownload file!'))
       }

--- a/components/AdminUserDashboard.tsx
+++ b/components/AdminUserDashboard.tsx
@@ -38,8 +38,10 @@ export default function AdminUserDashboard(): JSX.Element {
               <UserList key={item.value} summaryView type={item.value} />
             ))}
           </div>
-          <DailyStatsDashboard />
           {hasApiManager && <RequestLogsDashboard isAdmin summaryView />}
+        </Tab>
+        <Tab eventKey="daiystats" title="Daily Stats">
+          <DailyStatsDashboard />
         </Tab>
         <Tab eventKey="errors" title="Errors">
           <ErrorEventsDashboard />

--- a/components/AdminUserDashboard.tsx
+++ b/components/AdminUserDashboard.tsx
@@ -40,7 +40,7 @@ export default function AdminUserDashboard(): JSX.Element {
           </div>
           {hasApiManager && <RequestLogsDashboard isAdmin summaryView />}
         </Tab>
-        <Tab eventKey="daiystats" title="Daily Stats">
+        <Tab eventKey="dailystats" title="Daily Stats">
           <DailyStatsDashboard />
         </Tab>
         <Tab eventKey="errors" title="Errors">

--- a/components/AdminUserDashboard.tsx
+++ b/components/AdminUserDashboard.tsx
@@ -12,6 +12,7 @@ import CDPUserDashboard from './CDPUserDashboard'
 import ErrorEventsDashboard from './ErrorEventsDashboard'
 import RequestLogsDashboard from './RequestLogsDashboard'
 import UserList from './UserList'
+import DailyStatsDashboard from './DailyStatsDashboard'
 
 export default function AdminUserDashboard(): JSX.Element {
   const {
@@ -37,6 +38,7 @@ export default function AdminUserDashboard(): JSX.Element {
               <UserList key={item.value} summaryView type={item.value} />
             ))}
           </div>
+          <DailyStatsDashboard />
           {hasApiManager && <RequestLogsDashboard isAdmin summaryView />}
         </Tab>
         <Tab eventKey="errors" title="Errors">

--- a/components/ApiKeyUsageChart.tsx
+++ b/components/ApiKeyUsageChart.tsx
@@ -6,6 +6,7 @@ import moment from 'moment'
 import { Button } from 'react-bootstrap'
 
 import { Requests, Plan, GraphNumberValue } from '../types/graph'
+
 import Chart from './Chart'
 
 export type Props = {
@@ -157,12 +158,12 @@ class ApiKeyUsageChart extends Component<Props> {
       <Chart
         data={CHART_DATA}
         entityType="requests"
-        title={(
+        title={
           <>
             {this._renderChartTitle()}
             {this._renderKeyInfo()}
           </>
-        )}
+        }
       />
     )
   }

--- a/components/ApiKeyUsageChart.tsx
+++ b/components/ApiKeyUsageChart.tsx
@@ -4,18 +4,9 @@ import { Key } from '@styled-icons/fa-solid/Key'
 import clone from 'clone'
 import moment from 'moment'
 import { Button } from 'react-bootstrap'
-import {
-  XYPlot,
-  XAxis,
-  YAxis,
-  VerticalGridLines,
-  HorizontalGridLines,
-  VerticalRectSeries,
-  RectSeriesPoint,
-  RVValueEventHandler
-} from 'react-vis'
 
-import { GraphValue, Requests, Plan } from '../types/graph'
+import { Requests, Plan, GraphNumberValue } from '../types/graph'
+import Chart from './Chart'
 
 export type Props = {
   aggregatedView?: boolean
@@ -27,18 +18,7 @@ export type Props = {
  * Renders a chart showing API Key usage (requests over time) for a particular
  * API key.
  */
-class ApiKeyUsageChart extends Component<Props, { value: GraphValue | null }> {
-  constructor(props: Props) {
-    super(props)
-    this.state = {
-      value: null
-    }
-  }
-
-  handleClearValue = () => {
-    this.setState({ value: null })
-  }
-
+class ApiKeyUsageChart extends Component<Props> {
   _renderChartTitle = () => {
     const { aggregatedView, isAdmin } = this.props
     // Do not show chart title for non-admin users.
@@ -140,12 +120,6 @@ class ApiKeyUsageChart extends Component<Props, { value: GraphValue | null }> {
       ? null
       : (this.props.id && this.props?.plan?.apiUsers?.[this.props.id]) || null
 
-  handleSetValue: RVValueEventHandler<RectSeriesPoint> = (
-    data: RectSeriesPoint
-  ) => {
-    this.setState({ value: data })
-  }
-
   handleViewApiKey = () => {
     const { id, plan } = this.props
     if (!id || !plan) return
@@ -164,8 +138,6 @@ class ApiKeyUsageChart extends Component<Props, { value: GraphValue | null }> {
 
   render() {
     const { aggregatedView, id, plan } = this.props
-    const { value } = this.state
-    const ONE_DAY_MILLIS = 86400000
     const startDate = moment(plan?.result.startDate)
     if (!aggregatedView && !id) {
       console.warn('Cannot show non-aggregated view if id prop is undefined.')
@@ -174,55 +146,24 @@ class ApiKeyUsageChart extends Component<Props, { value: GraphValue | null }> {
     // Render the # of requests per API key on each day beginning
     // with the start date.
     const requestData = this._getRequestData()
-    const timestamp = startDate.valueOf()
-    let rangeMax = 0
     // Format request data for chart component.
-    const CHART_DATA: RectSeriesPoint[] =
+    const CHART_DATA: GraphNumberValue[] =
       requestData?.map((value, i) => {
         if (i > 0) startDate.add(1, 'days')
-        const begin = startDate.valueOf()
         // @ts-ignore TYPESCRIPT TODO: what is going on here?
-        const y = value[0]
-        const end = begin + ONE_DAY_MILLIS
-        if (y > rangeMax) rangeMax = y
-        return { x: end, x0: begin, y, y0: 0 }
+        return { x: startDate.valueOf(), y: value[0] }
       }) || []
-    const maxY = rangeMax === 0 ? 10 : Math.ceil(rangeMax / 10) * 10
     return (
-      <div className="usage-list" style={{ display: 'inline-block' }}>
-        {this._renderChartTitle()}
-        {this._renderKeyInfo()}
-        <XYPlot
-          height={300}
-          style={{ overflow: 'initial' }}
-          width={600} // Round up max y value to the nearest 10
-          xDomain={[
-            timestamp - 2 * ONE_DAY_MILLIS,
-            timestamp + 30 * ONE_DAY_MILLIS
-          ]}
-          yDomain={[0, maxY]}
-        >
-          <VerticalGridLines />
-          <HorizontalGridLines />
-          <XAxis tickFormat={(d) => moment(d).format('MMM DD')} />
-          <YAxis />
-          <VerticalRectSeries
-            data={CHART_DATA}
-            onValueMouseOut={this.handleClearValue} // Update value on mouse over/out.
-            onValueMouseOver={this.handleSetValue}
-            style={{ stroke: '#fff' }}
-          />
-        </XYPlot>
-        <p style={{ textAlign: 'center' }}>
-          {value ? (
-            <>
-              {moment(value.x).format('MMM DD')}: {value.y} requests
-            </>
-          ) : (
-            <>[Hover over bars to see values.]</>
-          )}
-        </p>
-      </div>
+      <Chart
+        data={CHART_DATA}
+        entityType="requests"
+        title={(
+          <>
+            {this._renderChartTitle()}
+            {this._renderKeyInfo()}
+          </>
+        )}
+      />
     )
   }
 }

--- a/components/CDPUserDashboard.tsx
+++ b/components/CDPUserDashboard.tsx
@@ -98,7 +98,9 @@ const CDPUserDashboard = (props: Props): JSX.Element => {
 
   const [swrData, setServerResponse] = useState<{
     // TODO: Shared type
-    data?: any
+    data?: {
+      data: CDPFile[]
+    }
     error?: string
     message?: string
     status?: string
@@ -151,8 +153,7 @@ const CDPUserDashboard = (props: Props): JSX.Element => {
     fetchData()
   }, [auth0, currentlyDownloadingFile])
 
-  let files = Object.keys(swrData).length > 0 ? swrData?.data?.data || [] : []
-  files = files
+  const files = (swrData?.data?.data || [])
     .filter((file: CDPFile) => file?.size > 0)
     // Negative sorts "reverse alphabetically" which allows newest files to appear first
     .sort((a: CDPFile, b: CDPFile) => -a.key.localeCompare(b.key))

--- a/components/CDPUserDashboard.tsx
+++ b/components/CDPUserDashboard.tsx
@@ -97,7 +97,6 @@ const CDPUserDashboard = (props: Props): JSX.Element => {
   const url = `${CDP_FILES_URL}`
 
   const [swrData, setServerResponse] = useState<{
-    // TODO: Shared type
     data?: {
       data: CDPFile[]
     }

--- a/components/CDPUserDashboard.tsx
+++ b/components/CDPUserDashboard.tsx
@@ -144,7 +144,7 @@ const CDPUserDashboard = (props: Props): JSX.Element => {
       fakeDownloadLink.click()
 
       // Cleanup
-      document.body.removeChild(fakeDownloadLink)
+      //document.body.removeChild(fakeDownloadLink)
       setCurrentlyDownloadingFile('')
       setDownloadedFiles((d) => [...d, currentlyDownloadingFile])
     }

--- a/components/CDPUserDashboard.tsx
+++ b/components/CDPUserDashboard.tsx
@@ -151,9 +151,9 @@ const CDPUserDashboard = (props: Props): JSX.Element => {
     fetchData()
   }, [auth0, currentlyDownloadingFile])
 
-  let files = Object.keys(swrData).length > 0 ? swrData?.data?.data : []
+  let files = Object.keys(swrData).length > 0 ? (swrData?.data?.data || []) : []
   files = files
-    ?.filter((file: CDPFile) => file?.size > 0)
+    .filter((file: CDPFile) => file?.size > 0)
     // Negative sorts "reverse alphabetically" which allows newest files to appear first
     .sort((a: CDPFile, b: CDPFile) => -a.key.localeCompare(b.key))
 

--- a/components/CDPUserDashboard.tsx
+++ b/components/CDPUserDashboard.tsx
@@ -135,7 +135,6 @@ const CDPUserDashboard = (props: Props): JSX.Element => {
       const fakeDownloadLink = document.createElement('a')
       fakeDownloadLink.download = currentlyDownloadingFile
       fakeDownloadLink.href = downloadLink
-      fakeDownloadLink.className = 'fake-download-link'
 
       // Add fake download anchor to DOM
       document.body.appendChild(fakeDownloadLink)
@@ -144,7 +143,7 @@ const CDPUserDashboard = (props: Props): JSX.Element => {
       fakeDownloadLink.click()
 
       // Cleanup
-      //document.body.removeChild(fakeDownloadLink)
+      document.body.removeChild(fakeDownloadLink)
       setCurrentlyDownloadingFile('')
       setDownloadedFiles((d) => [...d, currentlyDownloadingFile])
     }

--- a/components/CDPUserDashboard.tsx
+++ b/components/CDPUserDashboard.tsx
@@ -135,6 +135,7 @@ const CDPUserDashboard = (props: Props): JSX.Element => {
       const fakeDownloadLink = document.createElement('a')
       fakeDownloadLink.download = currentlyDownloadingFile
       fakeDownloadLink.href = downloadLink
+      fakeDownloadLink.className = 'fake-download-link'
 
       // Add fake download anchor to DOM
       document.body.appendChild(fakeDownloadLink)

--- a/components/CDPUserDashboard.tsx
+++ b/components/CDPUserDashboard.tsx
@@ -151,7 +151,7 @@ const CDPUserDashboard = (props: Props): JSX.Element => {
     fetchData()
   }, [auth0, currentlyDownloadingFile])
 
-  let files = Object.keys(swrData).length > 0 ? (swrData?.data?.data || []) : []
+  let files = Object.keys(swrData).length > 0 ? swrData?.data?.data || [] : []
   files = files
     .filter((file: CDPFile) => file?.size > 0)
     // Negative sorts "reverse alphabetically" which allows newest files to appear first

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -76,13 +76,15 @@ class Chart extends Component<Props, { value: GraphValue | null }> {
     const ONE_DAY_MILLIS = 86400000
     const dateMargin = 2 * ONE_DAY_MILLIS
 
-    const { chartData, endDateMillis, rangeMax, startDateMillis } = this._getBounds()    
-    
+    const { chartData, endDateMillis, rangeMax, startDateMillis } = this._getBounds()
+
+    const renderedTitle = typeof title === 'string' ? <h3>{title}</h3> : title
+
     // Round up max y value to the nearest 10
     const maxY = rangeMax === 0 ? 10 : Math.ceil(rangeMax / 10) * 10
     return (
       <div className="usage-list" style={{ display: 'inline-block' }}>
-        <h3>{title}</h3>
+        {renderedTitle}
         <XYPlot
           height={300}
           style={{ overflow: 'initial' }}

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -1,5 +1,4 @@
 import React, { Component, ReactNode } from 'react'
-import { withAuth0, WithAuth0Props } from '@auth0/auth0-react'
 import moment from 'moment'
 import {
   XYPlot,
@@ -14,7 +13,7 @@ import {
 
 import { GraphNumberValue, GraphValue } from '../types/graph'
 
-export type Props = WithAuth0Props & {
+export type Props = {
   data: GraphNumberValue[]
   entityType: string
   title: ReactNode
@@ -121,4 +120,4 @@ class Chart extends Component<Props, { value: GraphValue | null }> {
   }
 }
 
-export default withAuth0(Chart)
+export default Chart

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -1,0 +1,122 @@
+import React, { Component, ReactNode } from 'react'
+import { withAuth0, WithAuth0Props } from '@auth0/auth0-react'
+import moment from 'moment'
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines,
+  VerticalRectSeries,
+  RectSeriesPoint,
+  RVValueEventHandler
+} from 'react-vis'
+
+import { GraphNumberValue, GraphValue } from '../types/graph'
+
+export type Props = WithAuth0Props & {
+  data: GraphNumberValue[]
+  entityType: string
+  title: ReactNode
+}
+/**
+ * Renders a chart with presets and default behaviors (e.g. hover over data to show value).
+ */
+class Chart extends Component<Props, { value: GraphValue | null }> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      value: null
+    }
+  }
+
+  handleClearValue = () => {
+    this.setState({ value: null })
+  }
+
+  /**
+   * Extract the ranges of the data provided.
+   */
+  _getBounds = () => {
+    const ONE_DAY_MILLIS = 86400000
+    let rangeMax = 0
+    let startDateMillis = Number.MAX_VALUE
+    let endDateMillis = 0
+
+    const chartData = this.props.data.map(({ x, y }): RectSeriesPoint => {
+      // End the x range one millisecond before so that the bar
+      // doesn't bleed into the next day and the chart doesn't associate the bar with the next day.
+      const end = x + ONE_DAY_MILLIS - 1
+      if (y > rangeMax) rangeMax = y
+      if (startDateMillis > x) startDateMillis = x
+      if (endDateMillis < end) endDateMillis = end
+      return { x: end, x0: x, y, y0: 0 }
+    })
+
+    return {
+      chartData,
+      endDateMillis,
+      rangeMax,
+      startDateMillis
+    }
+  }
+
+  handleSetValue: RVValueEventHandler<RectSeriesPoint> = (
+    data: RectSeriesPoint
+  ) => {
+    this.setState({ value: data })
+  }
+
+  render() {
+    const { data, entityType, title } = this.props
+    if (data.length === 0) return null
+
+    const days = 30
+    const { value } = this.state
+    const ONE_DAY_MILLIS = 86400000
+    const dateMargin = 2 * ONE_DAY_MILLIS
+
+    const { chartData, endDateMillis, rangeMax, startDateMillis } = this._getBounds()    
+    
+    // Round up max y value to the nearest 10
+    const maxY = rangeMax === 0 ? 10 : Math.ceil(rangeMax / 10) * 10
+    return (
+      <div className="usage-list" style={{ display: 'inline-block' }}>
+        <h3>{title}</h3>
+        <XYPlot
+          height={300}
+          style={{ overflow: 'initial' }}
+          width={600}
+          xDomain={[
+            startDateMillis - dateMargin,
+            // Display at least 30 days if data spans over less than 30 days.
+            Math.max(startDateMillis + days * ONE_DAY_MILLIS, endDateMillis) + dateMargin
+          ]}
+          yDomain={[0, maxY]}
+        >
+          <VerticalGridLines />
+          <HorizontalGridLines />
+          <XAxis tickFormat={(d) => moment(d).format('MMM DD')} />
+          <YAxis />
+          <VerticalRectSeries
+            data={chartData}
+            onValueMouseOut={this.handleClearValue} // Update value on mouse over/out.
+            onValueMouseOver={this.handleSetValue}
+            style={{ stroke: '#fff' }}
+          />
+        </XYPlot>
+        <p style={{ textAlign: 'center' }}>
+          {value ? (
+            <>
+              {moment(value.x).format('MMM DD')}: {value.y} {entityType}
+            </>
+          ) : (
+            <>[Hover over bars to see values.]</>
+          )}
+        </p>
+      </div>
+    )
+  }
+}
+
+export default withAuth0(Chart)

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -75,7 +75,8 @@ class Chart extends Component<Props, { value: GraphValue | null }> {
     const { value } = this.state
     const ONE_DAY_MILLIS = 86400000
 
-    const { chartData, endDateMillis, rangeMax, startDateMillis } = this._getBounds()
+    const { chartData, endDateMillis, rangeMax, startDateMillis } =
+      this._getBounds()
 
     const renderedTitle = typeof title === 'string' ? <h3>{title}</h3> : title
 

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -74,7 +74,6 @@ class Chart extends Component<Props, { value: GraphValue | null }> {
     const days = 30
     const { value } = this.state
     const ONE_DAY_MILLIS = 86400000
-    const dateMargin = 2 * ONE_DAY_MILLIS
 
     const { chartData, endDateMillis, rangeMax, startDateMillis } = this._getBounds()
 
@@ -90,9 +89,9 @@ class Chart extends Component<Props, { value: GraphValue | null }> {
           style={{ overflow: 'initial' }}
           width={600}
           xDomain={[
-            startDateMillis - dateMargin,
+            startDateMillis,
             // Display at least 30 days if data spans over less than 30 days.
-            Math.max(startDateMillis + days * ONE_DAY_MILLIS, endDateMillis) + dateMargin
+            Math.max(startDateMillis + days * ONE_DAY_MILLIS, endDateMillis)
           ]}
           yDomain={[0, maxY]}
         >

--- a/components/Chart.tsx
+++ b/components/Chart.tsx
@@ -18,6 +18,14 @@ export type Props = {
   entityType: string
   title: ReactNode
 }
+
+type ChartBounds = {
+  chartData: RectSeriesPoint[]
+  endDateMillis: number
+  rangeMax: number
+  startDateMillis: number
+}
+
 /**
  * Renders a chart with presets and default behaviors (e.g. hover over data to show value).
  */
@@ -29,14 +37,14 @@ class Chart extends Component<Props, { value: GraphValue | null }> {
     }
   }
 
-  handleClearValue = () => {
+  handleClearValue = (): void => {
     this.setState({ value: null })
   }
 
   /**
    * Extract the ranges of the data provided.
    */
-  _getBounds = () => {
+  _getBounds = (): ChartBounds => {
     const ONE_DAY_MILLIS = 86400000
     let rangeMax = 0
     let startDateMillis = Number.MAX_VALUE
@@ -66,9 +74,9 @@ class Chart extends Component<Props, { value: GraphValue | null }> {
     this.setState({ value: data })
   }
 
-  render() {
+  render(): JSX.Element | null {
     const { data, entityType, title } = this.props
-    if (data.length === 0) return null
+    if (!data.length) return null
 
     const days = 30
     const { value } = this.state

--- a/components/DailyStatsChart.tsx
+++ b/components/DailyStatsChart.tsx
@@ -20,9 +20,11 @@ export type Props = WithAuth0Props & {
  * API key.
  */
 class DailyStatsChart extends Component<Props> {
-  _getSeries = (series: keyof StatsRecord) => (this.props.records || []).map(
-    (value) => ({ x: value.date.valueOf(), y: value[series] || 0 })
-  )
+  _getSeries = (series: keyof StatsRecord) =>
+    (this.props.records || []).map((value) => ({
+      x: value.date.valueOf(),
+      y: value[series] || 0
+    }))
 
   render() {
     const { entityType, records, series } = this.props
@@ -30,13 +32,7 @@ class DailyStatsChart extends Component<Props> {
 
     // Render the given series on each day beginning with the start date.
     const data = this._getSeries(series)
-    return (
-      <Chart
-        data={data}
-        entityType={entityType}
-        title={entityType}
-      />
-    )
+    return <Chart data={data} entityType={entityType} title={entityType} />
   }
 }
 

--- a/components/DailyStatsChart.tsx
+++ b/components/DailyStatsChart.tsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { withAuth0, WithAuth0Props } from '@auth0/auth0-react'
 
 import Chart from './Chart'
 
@@ -10,7 +9,7 @@ export type StatsRecord = {
   tripRequests?: number
 }
 
-export type Props = WithAuth0Props & {
+export type Props = {
   entityType: string
   records: StatsRecord[]
   series: keyof StatsRecord
@@ -36,4 +35,4 @@ class DailyStatsChart extends Component<Props> {
   }
 }
 
-export default withAuth0(DailyStatsChart)
+export default DailyStatsChart

--- a/components/DailyStatsChart.tsx
+++ b/components/DailyStatsChart.tsx
@@ -47,20 +47,28 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
    */
   _getSeries = (series: keyof StatsRecord) => {
     let rangeMax = 0
+    let startDateMillis = Number.MAX_VALUE
+    let endDateMillis = 0
     const ONE_DAY_MILLIS = 86400000
     // Format request data for chart component.
+    // End the x range one millisecond before so that the bar
+    // doesn't bleed into the next day and the chart doesn't associate the bar with the next day.
     const chartData: RectSeriesPoint[] =
       this.props.records.map((value, i) => {
         const begin = value.date.valueOf()
         const y = value[series] || 0
-        const end = begin + ONE_DAY_MILLIS
+        const end = begin + ONE_DAY_MILLIS - 1
         if (y > rangeMax) rangeMax = y
+        if (startDateMillis > begin) startDateMillis = begin
+        if (endDateMillis < begin) endDateMillis = begin
         return { x: end, x0: begin, y, y0: 0 }
       }) || []
 
       return {
         chartData,
+        endDateMillis,
         rangeMax,
+        startDateMillis
       }
   }
 
@@ -76,13 +84,11 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
     const days = 30
     const { value } = this.state
     const ONE_DAY_MILLIS = 86400000
-    const startDate = moment(this.props.records[0].date)
 
     // Render the # of requests per API key on each day beginning
     // with the start date.
-    const otpUsersSeries = this._getSeries(this.props.series)
-    const timestamp = startDate.valueOf()
-    let rangeMax = otpUsersSeries.rangeMax
+    const seriesData = this._getSeries(this.props.series)
+    const { chartData, endDateMillis, rangeMax, startDateMillis } = seriesData
     const maxY = rangeMax === 0 ? 10 : Math.ceil(rangeMax / 10) * 10
     return (
       <div className="usage-list" style={{ display: 'inline-block' }}>
@@ -92,8 +98,9 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
           style={{ overflow: 'initial' }}
           width={600} // Round up max y value to the nearest 10
           xDomain={[
-            timestamp - 2 * ONE_DAY_MILLIS,
-            timestamp + 30 * ONE_DAY_MILLIS
+            startDateMillis - 2 * ONE_DAY_MILLIS,
+            // Display at least 30 days if a short time window was provided.
+            Math.min(startDateMillis + days * ONE_DAY_MILLIS, endDateMillis + 2 * ONE_DAY_MILLIS)
           ]}
           yDomain={[0, maxY]}
         >
@@ -102,7 +109,7 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
           <XAxis tickFormat={(d) => moment(d).format('MMM DD')} />
           <YAxis />
           <VerticalRectSeries
-            data={otpUsersSeries.chartData}
+            data={chartData}
             onValueMouseOut={this.handleClearValue} // Update value on mouse over/out.
             onValueMouseOver={this.handleSetValue}
             style={{ stroke: '#fff' }}

--- a/components/DailyStatsChart.tsx
+++ b/components/DailyStatsChart.tsx
@@ -89,6 +89,8 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
     // with the start date.
     const seriesData = this._getSeries(this.props.series)
     const { chartData, endDateMillis, rangeMax, startDateMillis } = seriesData
+    
+    // Round up max y value to the nearest 10
     const maxY = rangeMax === 0 ? 10 : Math.ceil(rangeMax / 10) * 10
     return (
       <div className="usage-list" style={{ display: 'inline-block' }}>
@@ -96,10 +98,10 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
         <XYPlot
           height={300}
           style={{ overflow: 'initial' }}
-          width={600} // Round up max y value to the nearest 10
+          width={600}
           xDomain={[
             startDateMillis - 2 * ONE_DAY_MILLIS,
-            // Display at least 30 days if a short time window was provided.
+            // Display at least 30 days if data spans over less than 30 days.
             Math.min(startDateMillis + days * ONE_DAY_MILLIS, endDateMillis + 2 * ONE_DAY_MILLIS)
           ]}
           yDomain={[0, maxY]}

--- a/components/DailyStatsChart.tsx
+++ b/components/DailyStatsChart.tsx
@@ -22,7 +22,9 @@ export type StatsRecord = {
 }
 
 export type Props = WithAuth0Props & {
+  entityType: string
   records: StatsRecord[]
+  series: keyof StatsRecord
 }
 /**
  * Renders a chart showing API Key usage (requests over time) for a particular
@@ -40,8 +42,28 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
     this.setState({ value: null })
   }
 
+  /**
+   * Format series data for chart component.
+   */
   _getSeries = (series: keyof StatsRecord) => {
-    return this.props.records.map(r => r[series])
+    let rangeMax = 0
+    const startDate = moment(this.props.records[0].date)
+    const ONE_DAY_MILLIS = 86400000
+    // Format request data for chart component.
+    const chartData: RectSeriesPoint[] =
+      this.props.records.map((value, i) => {
+        if (i > 0) startDate.add(1, 'days')
+        const begin = startDate.valueOf()
+        const y = value[series] || 0
+        const end = begin + ONE_DAY_MILLIS
+        if (y > rangeMax) rangeMax = y
+        return { x: end, x0: begin, y, y0: 0 }
+      }) || []
+
+      return {
+        chartData,
+        rangeMax,
+      }
   }
 
   handleSetValue: RVValueEventHandler<RectSeriesPoint> = (
@@ -51,6 +73,8 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
   }
 
   render() {
+    if (this.props.records.length === 0) return null
+
     const days = 30
     const { value } = this.state
     const ONE_DAY_MILLIS = 86400000
@@ -58,25 +82,13 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
 
     // Render the # of requests per API key on each day beginning
     // with the start date.
-    const dates = this._getSeries('date')
-    const otpUsers = this._getSeries('otpUsers')
+    const otpUsersSeries = this._getSeries(this.props.series)
     const timestamp = startDate.valueOf()
-    let rangeMax = 0
-    // Format request data for chart component.
-    const CHART_DATA: RectSeriesPoint[] =
-      this.props.records.map((value, i) => {
-        if (i > 0) startDate.add(1, 'days')
-        const begin = startDate.valueOf()
-        // @ts-ignore TYPESCRIPT TODO: what is going on here?
-        const y = value.otpUsers || 0
-        const end = begin + ONE_DAY_MILLIS
-        if (y > rangeMax) rangeMax = y
-        return { x: end, x0: begin, y, y0: 0 }
-      }) || []
+    let rangeMax = otpUsersSeries.rangeMax
     const maxY = rangeMax === 0 ? 10 : Math.ceil(rangeMax / 10) * 10
     return (
       <div className="usage-list" style={{ display: 'inline-block' }}>
-        <h3>Daily Stats</h3>
+        <h3>{this.props.entityType}</h3>
         <XYPlot
           height={300}
           style={{ overflow: 'initial' }}
@@ -92,7 +104,7 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
           <XAxis tickFormat={(d) => moment(d).format('MMM DD')} />
           <YAxis />
           <VerticalRectSeries
-            data={CHART_DATA}
+            data={otpUsersSeries.chartData}
             onValueMouseOut={this.handleClearValue} // Update value on mouse over/out.
             onValueMouseOver={this.handleSetValue}
             style={{ stroke: '#fff' }}
@@ -101,7 +113,7 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
         <p style={{ textAlign: 'center' }}>
           {value ? (
             <>
-              {moment(value.x).format('MMM DD')}: {value.y} users
+              {moment(value.x).format('MMM DD')}: {value.y} {this.props.entityType}
             </>
           ) : (
             <>[Hover over bars to see values.]</>

--- a/components/DailyStatsChart.tsx
+++ b/components/DailyStatsChart.tsx
@@ -84,6 +84,7 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
     const days = 30
     const { value } = this.state
     const ONE_DAY_MILLIS = 86400000
+    const dateMargin = 2 * ONE_DAY_MILLIS
 
     // Render the # of requests per API key on each day beginning
     // with the start date.
@@ -100,9 +101,9 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
           style={{ overflow: 'initial' }}
           width={600}
           xDomain={[
-            startDateMillis - 2 * ONE_DAY_MILLIS,
+            startDateMillis - dateMargin,
             // Display at least 30 days if data spans over less than 30 days.
-            Math.min(startDateMillis + days * ONE_DAY_MILLIS, endDateMillis + 2 * ONE_DAY_MILLIS)
+            Math.max(startDateMillis + days * ONE_DAY_MILLIS, endDateMillis) + dateMargin
           ]}
           yDomain={[0, maxY]}
         >

--- a/components/DailyStatsChart.tsx
+++ b/components/DailyStatsChart.tsx
@@ -47,13 +47,11 @@ class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
    */
   _getSeries = (series: keyof StatsRecord) => {
     let rangeMax = 0
-    const startDate = moment(this.props.records[0].date)
     const ONE_DAY_MILLIS = 86400000
     // Format request data for chart component.
     const chartData: RectSeriesPoint[] =
       this.props.records.map((value, i) => {
-        if (i > 0) startDate.add(1, 'days')
-        const begin = startDate.valueOf()
+        const begin = value.date.valueOf()
         const y = value[series] || 0
         const end = begin + ONE_DAY_MILLIS
         if (y > rangeMax) rangeMax = y

--- a/components/DailyStatsChart.tsx
+++ b/components/DailyStatsChart.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 
 import Chart from './Chart'
+import { GraphNumberValue } from '../types/graph'
 
 export type StatsRecord = {
   date: number
@@ -19,15 +20,15 @@ export type Props = {
  * API key.
  */
 class DailyStatsChart extends Component<Props> {
-  _getSeries = (series: keyof StatsRecord) =>
+  _getSeries = (series: keyof StatsRecord): GraphNumberValue[] =>
     (this.props.records || []).map((value) => ({
       x: value.date.valueOf(),
       y: value[series] || 0
     }))
 
-  render() {
+  render(): JSX.Element | null {
     const { entityType, records, series } = this.props
-    if (records.length === 0) return null
+    if (!records.length) return null
 
     // Render the given series on each day beginning with the start date.
     const data = this._getSeries(series)

--- a/components/DailyStatsChart.tsx
+++ b/components/DailyStatsChart.tsx
@@ -1,0 +1,115 @@
+import React, { Component } from 'react'
+import { withAuth0, WithAuth0Props } from '@auth0/auth0-react'
+import moment from 'moment'
+import {
+  XYPlot,
+  XAxis,
+  YAxis,
+  VerticalGridLines,
+  HorizontalGridLines,
+  VerticalRectSeries,
+  RectSeriesPoint,
+  RVValueEventHandler
+} from 'react-vis'
+
+import { GraphValue } from '../types/graph'
+
+export type StatsRecord = {
+  date: number
+  otpUsers?: number
+  otpUsersWithTripRequests?: number
+  tripRequests?: number
+}
+
+export type Props = WithAuth0Props & {
+  records: StatsRecord[]
+}
+/**
+ * Renders a chart showing API Key usage (requests over time) for a particular
+ * API key.
+ */
+class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      value: null
+    }
+  }
+
+  handleClearValue = () => {
+    this.setState({ value: null })
+  }
+
+  _getSeries = (series: keyof StatsRecord) => {
+    return this.props.records.map(r => r[series])
+  }
+
+  handleSetValue: RVValueEventHandler<RectSeriesPoint> = (
+    data: RectSeriesPoint
+  ) => {
+    this.setState({ value: data })
+  }
+
+  render() {
+    const days = 30
+    const { value } = this.state
+    const ONE_DAY_MILLIS = 86400000
+    const startDate = moment(this.props.records[0].date)
+
+    // Render the # of requests per API key on each day beginning
+    // with the start date.
+    const dates = this._getSeries('date')
+    const otpUsers = this._getSeries('otpUsers')
+    const timestamp = startDate.valueOf()
+    let rangeMax = 0
+    // Format request data for chart component.
+    const CHART_DATA: RectSeriesPoint[] =
+      this.props.records.map((value, i) => {
+        if (i > 0) startDate.add(1, 'days')
+        const begin = startDate.valueOf()
+        // @ts-ignore TYPESCRIPT TODO: what is going on here?
+        const y = value.otpUsers || 0
+        const end = begin + ONE_DAY_MILLIS
+        if (y > rangeMax) rangeMax = y
+        return { x: end, x0: begin, y, y0: 0 }
+      }) || []
+    const maxY = rangeMax === 0 ? 10 : Math.ceil(rangeMax / 10) * 10
+    return (
+      <div className="usage-list" style={{ display: 'inline-block' }}>
+        <h3>Daily Stats</h3>
+        <XYPlot
+          height={300}
+          style={{ overflow: 'initial' }}
+          width={600} // Round up max y value to the nearest 10
+          xDomain={[
+            timestamp - 2 * ONE_DAY_MILLIS,
+            timestamp + 30 * ONE_DAY_MILLIS
+          ]}
+          yDomain={[0, maxY]}
+        >
+          <VerticalGridLines />
+          <HorizontalGridLines />
+          <XAxis tickFormat={(d) => moment(d).format('MMM DD')} />
+          <YAxis />
+          <VerticalRectSeries
+            data={CHART_DATA}
+            onValueMouseOut={this.handleClearValue} // Update value on mouse over/out.
+            onValueMouseOver={this.handleSetValue}
+            style={{ stroke: '#fff' }}
+          />
+        </XYPlot>
+        <p style={{ textAlign: 'center' }}>
+          {value ? (
+            <>
+              {moment(value.x).format('MMM DD')}: {value.y} users
+            </>
+          ) : (
+            <>[Hover over bars to see values.]</>
+          )}
+        </p>
+      </div>
+    )
+  }
+}
+
+export default withAuth0(DailyStatsChart)

--- a/components/DailyStatsChart.tsx
+++ b/components/DailyStatsChart.tsx
@@ -1,18 +1,7 @@
 import React, { Component } from 'react'
 import { withAuth0, WithAuth0Props } from '@auth0/auth0-react'
-import moment from 'moment'
-import {
-  XYPlot,
-  XAxis,
-  YAxis,
-  VerticalGridLines,
-  HorizontalGridLines,
-  VerticalRectSeries,
-  RectSeriesPoint,
-  RVValueEventHandler
-} from 'react-vis'
 
-import { GraphValue } from '../types/graph'
+import Chart from './Chart'
 
 export type StatsRecord = {
   date: number
@@ -30,104 +19,23 @@ export type Props = WithAuth0Props & {
  * Renders a chart showing API Key usage (requests over time) for a particular
  * API key.
  */
-class DailyStatsChart extends Component<Props, { value: GraphValue | null }> {
-  constructor(props: Props) {
-    super(props)
-    this.state = {
-      value: null
-    }
-  }
-
-  handleClearValue = () => {
-    this.setState({ value: null })
-  }
-
-  /**
-   * Format series data for chart component.
-   */
-  _getSeries = (series: keyof StatsRecord) => {
-    let rangeMax = 0
-    let startDateMillis = Number.MAX_VALUE
-    let endDateMillis = 0
-    const ONE_DAY_MILLIS = 86400000
-    // Format request data for chart component.
-    // End the x range one millisecond before so that the bar
-    // doesn't bleed into the next day and the chart doesn't associate the bar with the next day.
-    const chartData: RectSeriesPoint[] =
-      this.props.records.map((value, i) => {
-        const begin = value.date.valueOf()
-        const y = value[series] || 0
-        const end = begin + ONE_DAY_MILLIS - 1
-        if (y > rangeMax) rangeMax = y
-        if (startDateMillis > begin) startDateMillis = begin
-        if (endDateMillis < begin) endDateMillis = begin
-        return { x: end, x0: begin, y, y0: 0 }
-      }) || []
-
-      return {
-        chartData,
-        endDateMillis,
-        rangeMax,
-        startDateMillis
-      }
-  }
-
-  handleSetValue: RVValueEventHandler<RectSeriesPoint> = (
-    data: RectSeriesPoint
-  ) => {
-    this.setState({ value: data })
-  }
+class DailyStatsChart extends Component<Props> {
+  _getSeries = (series: keyof StatsRecord) => (this.props.records || []).map(
+    (value) => ({ x: value.date.valueOf(), y: value[series] || 0 })
+  )
 
   render() {
-    if (this.props.records.length === 0) return null
+    const { entityType, records, series } = this.props
+    if (records.length === 0) return null
 
-    const days = 30
-    const { value } = this.state
-    const ONE_DAY_MILLIS = 86400000
-    const dateMargin = 2 * ONE_DAY_MILLIS
-
-    // Render the # of requests per API key on each day beginning
-    // with the start date.
-    const seriesData = this._getSeries(this.props.series)
-    const { chartData, endDateMillis, rangeMax, startDateMillis } = seriesData
-    
-    // Round up max y value to the nearest 10
-    const maxY = rangeMax === 0 ? 10 : Math.ceil(rangeMax / 10) * 10
+    // Render the given series on each day beginning with the start date.
+    const data = this._getSeries(series)
     return (
-      <div className="usage-list" style={{ display: 'inline-block' }}>
-        <h3>{this.props.entityType}</h3>
-        <XYPlot
-          height={300}
-          style={{ overflow: 'initial' }}
-          width={600}
-          xDomain={[
-            startDateMillis - dateMargin,
-            // Display at least 30 days if data spans over less than 30 days.
-            Math.max(startDateMillis + days * ONE_DAY_MILLIS, endDateMillis) + dateMargin
-          ]}
-          yDomain={[0, maxY]}
-        >
-          <VerticalGridLines />
-          <HorizontalGridLines />
-          <XAxis tickFormat={(d) => moment(d).format('MMM DD')} />
-          <YAxis />
-          <VerticalRectSeries
-            data={chartData}
-            onValueMouseOut={this.handleClearValue} // Update value on mouse over/out.
-            onValueMouseOver={this.handleSetValue}
-            style={{ stroke: '#fff' }}
-          />
-        </XYPlot>
-        <p style={{ textAlign: 'center' }}>
-          {value ? (
-            <>
-              {moment(value.x).format('MMM DD')}: {value.y} {this.props.entityType}
-            </>
-          ) : (
-            <>[Hover over bars to see values.]</>
-          )}
-        </p>
-      </div>
+      <Chart
+        data={data}
+        entityType={entityType}
+        title={entityType}
+      />
     )
   }
 }

--- a/components/DailyStatsDashboard.tsx
+++ b/components/DailyStatsDashboard.tsx
@@ -16,8 +16,7 @@ function DailyStatsDashboard(): JSX.Element | null {
   const result = useSWR(DAILY_STATS_URL)
   if (!auth.isAuthenticated) return null
   const { data: swrData = {}, isValidating } = result
-  const { data } = swrData
-  const records = data?.data || []
+  const records = swrData.data?.data || []
   return (
     <div>
       <h2>Daily Stats</h2>

--- a/components/DailyStatsDashboard.tsx
+++ b/components/DailyStatsDashboard.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
+import { Button } from 'react-bootstrap'
+import { Sync } from '@styled-icons/fa-solid/Sync'
 import { useAuth0 } from '@auth0/auth0-react'
 import useSWR, { mutate } from 'swr'
 
 import DailyStatsChart from './DailyStatsChart'
+import FetchMessage from './FetchMessage'
 
 const DAILY_STATS_URL = `${process.env.API_BASE_URL}/api/secure/dailystats`
 
@@ -10,11 +13,25 @@ function DailyStatsDashboard(): JSX.Element | null {
   const auth = useAuth0()
   const result = useSWR(DAILY_STATS_URL)
   if (!auth.isAuthenticated) return null
-  const { data: swrData = {} } = result
+  const { data: swrData = {}, isValidating } = result
   const { data } = swrData
   return (
     <div>
-      <DailyStatsChart records={data.data || []} />
+      <h2>Daily Stats</h2>
+      <div className="controls">
+        <Button
+          className="mr-3"
+          disabled={isValidating}
+          onClick={() => mutate(DAILY_STATS_URL)}
+        >
+          <Sync size={20} />
+        </Button>
+        <FetchMessage result={result} />
+      </div>
+
+      {(!isValidating && (
+        <DailyStatsChart records={data?.data || []} />
+      ))}
       <style jsx>
         {`
           .controls {

--- a/components/DailyStatsDashboard.tsx
+++ b/components/DailyStatsDashboard.tsx
@@ -7,7 +7,7 @@ import useSWR, { mutate } from 'swr'
 import DailyStatsChart from './DailyStatsChart'
 import FetchMessage from './FetchMessage'
 
-const DAILY_STATS_URL = `${process.env.API_BASE_URL}/api/secure/dailystats`
+const DAILY_STATS_URL = `${process.env.API_BASE_URL}/api/secure/dailystats?fromDate=2025-01-01`
 
 function DailyStatsDashboard(): JSX.Element | null {
   const auth = useAuth0()
@@ -15,6 +15,7 @@ function DailyStatsDashboard(): JSX.Element | null {
   if (!auth.isAuthenticated) return null
   const { data: swrData = {}, isValidating } = result
   const { data } = swrData
+  const records = data?.data || []
   return (
     <div>
       <h2>Daily Stats</h2>
@@ -30,11 +31,11 @@ function DailyStatsDashboard(): JSX.Element | null {
       </div>
 
       {(!isValidating && (
-        <>
-          <DailyStatsChart entityType="OTP Users" records={data?.data || []} series="otpUsers" />
-          <DailyStatsChart entityType="OTP Users With Trip Requests" records={data?.data || []} series="otpUsersWithTripRequests" />
-          <DailyStatsChart entityType="Trip Requests" records={data?.data || []} series="tripRequests" />
-        </>
+        <div>
+          <DailyStatsChart entityType="OTP Users" records={records} series="otpUsers" />
+          <DailyStatsChart entityType="OTP Users With Trip Requests" records={records} series="otpUsersWithTripRequests" />
+          <DailyStatsChart entityType="Trip Requests" records={records} series="tripRequests" />
+        </div>
       ))}
       <style jsx>
         {`

--- a/components/DailyStatsDashboard.tsx
+++ b/components/DailyStatsDashboard.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { useAuth0 } from '@auth0/auth0-react'
+import useSWR, { mutate } from 'swr'
+
+import DailyStatsChart from './DailyStatsChart'
+
+const DAILY_STATS_URL = `${process.env.API_BASE_URL}/api/secure/dailystats`
+
+function DailyStatsDashboard(): JSX.Element | null {
+  const auth = useAuth0()
+  const result = useSWR(DAILY_STATS_URL)
+  if (!auth.isAuthenticated) return null
+  const { data: swrData = {} } = result
+  const { data } = swrData
+  return (
+    <div>
+      <DailyStatsChart records={data.data || []} />
+      <style jsx>
+        {`
+          .controls {
+            align-items: center;
+            display: flex;
+          }
+          .push {
+            margin-left: auto;
+          }
+          .usage-list {
+            display: inline-block;
+            margin: 5px;
+          }
+
+          ul {
+            padding: 0;
+          }
+
+          li {
+            list-style: none;
+            margin: 5px 0;
+          }
+        `}
+      </style>
+    </div>
+  )
+}
+
+export default DailyStatsDashboard

--- a/components/DailyStatsDashboard.tsx
+++ b/components/DailyStatsDashboard.tsx
@@ -30,13 +30,25 @@ function DailyStatsDashboard(): JSX.Element | null {
         <FetchMessage result={result} />
       </div>
 
-      {(!isValidating && (
+      {!isValidating && (
         <div>
-          <DailyStatsChart entityType="OTP Users" records={records} series="otpUsers" />
-          <DailyStatsChart entityType="OTP Users With Trip Requests" records={records} series="otpUsersWithTripRequests" />
-          <DailyStatsChart entityType="Trip Requests" records={records} series="tripRequests" />
+          <DailyStatsChart
+            entityType="OTP Users"
+            records={records}
+            series="otpUsers"
+          />
+          <DailyStatsChart
+            entityType="OTP Users With Trip Requests"
+            records={records}
+            series="otpUsersWithTripRequests"
+          />
+          <DailyStatsChart
+            entityType="Trip Requests"
+            records={records}
+            series="tripRequests"
+          />
         </div>
-      ))}
+      )}
       <style jsx>
         {`
           .controls {

--- a/components/DailyStatsDashboard.tsx
+++ b/components/DailyStatsDashboard.tsx
@@ -30,7 +30,11 @@ function DailyStatsDashboard(): JSX.Element | null {
       </div>
 
       {(!isValidating && (
-        <DailyStatsChart records={data?.data || []} />
+        <>
+          <DailyStatsChart entityType="OTP Users" records={data?.data || []} series="otpUsers" />
+          <DailyStatsChart entityType="OTP Users With Trip Requests" records={data?.data || []} series="otpUsersWithTripRequests" />
+          <DailyStatsChart entityType="Trip Requests" records={data?.data || []} series="tripRequests" />
+        </>
       ))}
       <style jsx>
         {`

--- a/components/DailyStatsDashboard.tsx
+++ b/components/DailyStatsDashboard.tsx
@@ -7,7 +7,9 @@ import useSWR, { mutate } from 'swr'
 import DailyStatsChart from './DailyStatsChart'
 import FetchMessage from './FetchMessage'
 
-const DAILY_STATS_URL = `${process.env.API_BASE_URL}/api/secure/dailystats?fromDate=2025-01-01`
+// Set a default start date for query (if omitted, OTP-middleware limits to the past 30 days).
+const defaultStartDate = '2025-09-01'
+const DAILY_STATS_URL = `${process.env.API_BASE_URL}/api/secure/dailystats?fromDate=${defaultStartDate}`
 
 function DailyStatsDashboard(): JSX.Element | null {
   const auth = useAuth0()

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "otp-admin-ui",
   "version": "1.0.0",
   "main": "index.js",
-  "engines": { "node": "18.x" },
+  "engines": { "node": "22.x" },
   "license": "MIT",
   "scripts": {
     "build": "next build",

--- a/types/graph.ts
+++ b/types/graph.ts
@@ -14,4 +14,9 @@ export type GraphValue = {
   y: string | number | Date
 }
 
+export type GraphNumberValue = {
+  x: number
+  y: number
+}
+
 export type Requests = [number, number]


### PR DESCRIPTION
This PR adds a tab page with charts for daily number of trip requests, and OTP users with trip requests, and total number of OTP users. Daily stats are populated only for OTP-middleware deployments that include https://github.com/ibi-group/otp-middleware/pull/349.

<img width="416" height="437" alt="image" src="https://github.com/user-attachments/assets/2b7f8ff0-abd4-4517-be1d-39f4d0a23e5c" />
