### PR TITLE
Remove predev script

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 22.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v1
         with:
-          node-version: 22.x
+          node-version: 24.x
       - name: Install npm packages using cache
         uses: bahmutov/npm-install@v1
         with:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 22.x
+      - name: Use Node.js 24.x
         uses: actions/setup-node@v1
         with:
-          node-version: 22.x
+          node-version: 24.x
       - name: Install npm packages using cache
         uses: bahmutov/npm-install@v1
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,5 @@
+save-exact=true
+prefer-offline=false
+ignore-scripts=true
+min-release-age=7
+allow-git=none

--- a/package.json
+++ b/package.json
@@ -6,13 +6,12 @@
   "license": "MIT",
   "scripts": {
     "build": "next build",
-    "dev": "next",
+    "dev": "yarn && next",
     "deploy": "vercel",
     "lint": "yarn lint-types && yarn lint-code",
     "lint-code": "tsdx lint components pages util --quiet",
     "lint-docs": "documentation lint {components,pages,util}/**/*.js",
     "lint-types": "yarn tsc",
-    "predev": "yarn",
     "e2e-test": "cp -r __tests__/e2e/env.test .env.build && yarn jest __tests__/e2e/"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "otp-admin-ui",
   "version": "1.0.0",
   "main": "index.js",
-  "engines": { "node": "22.x" },
+  "engines": { "node": "24.x" },
   "license": "MIT",
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
This PR removes the `predev` script and adds restrictions during the packages that can be copied and executed during install. CI scripts are updated to use Node 24.